### PR TITLE
add 32bit architectures for windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,15 @@ environment:
   matrix:
     # Note: Because we have to separate the py2 and py3 components due to compiler version, we have a race condition for non-python packages.
     # Not sure how to resolve this, but maybe we should be tracking the VS version in the build string anyway?
+    - TARGET_ARCH: "x86"
+      CONDA_PY: "27"
+      PY_CONDITION: "python >=2.7,<3"
+    - TARGET_ARCH: "x86"
+      CONDA_PY: "34"
+      PY_CONDITION: "python >=3.4,<3.5"
+    - TARGET_ARCH: "x86"
+      CONDA_PY: "35"
+      PY_CONDITION: "python >=3.5"
     - TARGET_ARCH: "x64"
       CONDA_PY: "27"
       PY_CONDITION: "python >=2.7,<3"


### PR DESCRIPTION
Running into some 32bit vs py27 builds on conda forge:

https://github.com/conda-forge/staged-recipes/pull/710

Turns out, the matrix didn't include them here. Adding them!