### PR TITLE
Allow environment names with one letter 

### DIFF
--- a/nb_conda/envmanager.py
+++ b/nb_conda/envmanager.py
@@ -20,6 +20,7 @@ def pkg_info(s):
         'build':   build
     }
 
+
 MAX_LOG_OUTPUT = 6000
 
 # try to match lines of json

--- a/nb_conda/handlers.py
+++ b/nb_conda/handlers.py
@@ -215,6 +215,7 @@ class CondaSearcher(object):
 
         return None
 
+
 searcher = CondaSearcher()
 
 

--- a/nb_conda/handlers.py
+++ b/nb_conda/handlers.py
@@ -259,7 +259,7 @@ _env_action_regex = r"(?P<action>create|export|clone|delete)"
 
 # there is almost no text that is invalid, but no hyphens up front, please
 # neither all these suspicious but valid caracthers...
-_env_regex = r"(?P<env>[^/&+$?@<>%*-][^/&+$?@<>%*]*)$"
+_env_regex = r"(?P<env>[^/&+$?@<>%*-][^/&+$?@<>%*]*)"
 
 # no hyphens up front, please
 _pkg_regex = r"(?P<pkg>[^\-][\-\da-zA-Z\._]+)"

--- a/nb_conda/handlers.py
+++ b/nb_conda/handlers.py
@@ -258,7 +258,8 @@ class SearchHandler(EnvBaseHandler):
 _env_action_regex = r"(?P<action>create|export|clone|delete)"
 
 # there is almost no text that is invalid, but no hyphens up front, please
-_env_regex = r"(?P<env>[^\-][^\/]+)"
+# neither all these suspicious but valid caracthers...
+_env_regex = r"(?P<env>[^/&+$?@<>%*-][^/&+$?@<>%*]*)$"
 
 # no hyphens up front, please
 _pkg_regex = r"(?P<pkg>[^\-][\-\da-zA-Z\._]+)"


### PR DESCRIPTION
But also get rid of suspicious characters...

@martindurant provided this regex after some discussion at https://github.com/ContinuumIO/aen-issues/issues/680