### PR TITLE
Add yaml files for jupyter_nbextensions_configurator

### DIFF
--- a/nb_conda/static/main.yaml
+++ b/nb_conda/static/main.yaml
@@ -1,0 +1,15 @@
+# This file declares this nbextension to the jupyter_nbextensions_configurator.
+# See
+#     https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator
+# for further details.
+Type: Jupyter Notebook Extension
+Name: Conda Notebook menu item
+Description: |
+  Adds a Conda Packages item to the Kernel menu. Selecting this item displays
+  the list of Conda packages in the environment associated with the running
+  kernel, and the list of available packages.
+  You can perform the same actions as in the Conda tab, but only against the
+  current environment.
+Main: main.js
+Compatibility: 4.x
+Link: https://github.com/Anaconda-Platform/nb_conda

--- a/nb_conda/static/tree.yaml
+++ b/nb_conda/static/tree.yaml
@@ -1,0 +1,14 @@
+# This file declares this nbextension to the jupyter_nbextensions_configurator.
+# See
+#     https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator
+# for further details.
+Type: Jupyter Notebook Extension
+Name: Conda tab
+Description: |
+  Adds a Conda tab to the Jupyter file browser which can list the currently
+  existing Conda environments, and packages installed in the selected
+  environment. In addition, you can install new packages and update installed
+  packages form the tab.
+Main: tree.js
+Compatibility: 4.x
+Link: https://github.com/Anaconda-Platform/nb_conda


### PR DESCRIPTION
As discussed in https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/489 (see https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/489#issuecomment-274207331), this PR adds yaml files describing the nbextensions to the [jupyter_nbextensions_configurator](https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator).

It's common to add a link to a local readme file for configurator extensions, but there are currently no readme.md files in the static folder, so I've added links to the github repo instead, which shows the main readme.

I've attempted to adapt text from the main readme for the descriptions, but no doubt they could be improved...