### PR TITLE
Update nb_conda to be compatible with 4.3.1 and higher

### DIFF
--- a/nb_conda/envmanager.py
+++ b/nb_conda/envmanager.py
@@ -13,11 +13,19 @@ from traitlets import Dict
 
 
 def pkg_info(s):
-    name, version, build = s.rsplit('-', 2)
+    try:
+        # for conda >= 4.3, `s` should be a dict
+        name = s['name']
+        version = s['version']
+        build = s.get('build_string') or s['build']
+    except TypeError:
+        # parse legacy string version for information
+        name, version, build = s.rsplit('-', 2)
+
     return {
-        'name':    name,
+        'name': name,
         'version': version,
-        'build':   build
+        'build': build
     }
 
 

--- a/nb_conda/static/main.js
+++ b/nb_conda/static/main.js
@@ -6,6 +6,7 @@ define(function(require) {
     var views = require('./views');
     var urls = require('./urls');
     var dialog = require('base/js/dialog');
+    var utils = require('base/js/utils');
     var $view = $('#conda');
 
     jQuery.fn.center = function () {
@@ -36,7 +37,7 @@ define(function(require) {
     function load_conda_view() {
         if($view.length === 0) {
             // Not loaded yet
-            $.ajax(urls.static_url + 'tab.html', {
+            utils.ajax(urls.static_url + 'tab.html', {
                 dataType: 'html',
                 success: function(tab_html, status, xhr) {
                     // Load the 'conda tab', hide the Environments portion
@@ -107,7 +108,7 @@ define(function(require) {
             .attr('href', urls.static_url + 'conda.css')
         );
 
-        $.ajax(urls.static_url + 'menu.html', {
+        utils.ajax(urls.static_url + 'menu.html', {
             dataType: 'html',
             success: function(menu_html, status, xhr) {
                 // Configure Conda items in Kernel menu

--- a/nb_conda/static/models.js
+++ b/nb_conda/static/models.js
@@ -53,7 +53,7 @@ define([
                 error:   error_callback
             });
 
-            return $.ajax(urls.api_url + 'environments', settings);
+            return utils.ajax(urls.api_url + 'environments', settings);
         },
 
         select: function(env) {
@@ -110,7 +110,7 @@ define([
 
         var url = urls.api_url + utils.url_join_encode(
           'environments', environments.selected.name, 'packages', action);
-        return $.ajax(url, settings);
+        return utils.ajax(url, settings);
     }
 
     function conda_env_action(env, action, on_success, on_error, data) {
@@ -125,7 +125,7 @@ define([
 
         var url = urls.api_url + utils.url_join_encode(
             'environments', env.name, action);
-        return $.ajax(url, settings);
+        return utils.ajax(url, settings);
     }
 
     var available = {
@@ -163,7 +163,7 @@ define([
 
             var url = urls.api_url + utils.url_path_join(
                 'packages', 'available');
-            return $.ajax(url, settings);
+            return utils.ajax(url, settings);
         },
 
         get_selection: function() {
@@ -263,7 +263,7 @@ define([
 
             var url = urls.api_url + utils.url_join_encode(
                 'environments', query);
-            return $.ajax(url, settings);
+            return utils.ajax(url, settings);
         },
 
         _update: function(dry_run, handler) {

--- a/nb_conda/static/tree.js
+++ b/nb_conda/static/tree.js
@@ -1,6 +1,7 @@
 define(function(require) {
     var $ = require('jquery');
     var Jupyter = require('base/js/namespace');
+    var utils = require('base/js/utils');
     var models = require('./models');
     var views = require('./views');
     var urls = require('./urls');
@@ -15,7 +16,7 @@ define(function(require) {
             .attr('href', urls.static_url + 'conda.css')
         );
 
-        $.ajax(urls.static_url + 'tab.html', {
+        utils.ajax(urls.static_url + 'tab.html', {
             dataType: 'html',
             success: function(env_html, status, xhr) {
                 // Configure Conda tab


### PR DESCRIPTION
[Jupyter notebook blog](http://blog.jupyter.org/2016/12/21/jupyter-notebook-4-3-1/) post about version 4.3.1 introduced a fix for **CVE-2016-9971** but in doing so, caused some issues for RESTful interfaces.  

When the `nb_conda` extension is activated (and tested with Notebook version 4.4.1), actions like installing a package generates a "Forbidden" error dialog and the server log only shows a 403 error on the POST url:

`[W 00:44:28.973 NotebookApp] 403 POST /conda/environments/root/packages/install (n.n.n.n): '_xsrf' argument missing from POST`

Since the code already references the `base/js/utils` module, and that module already implements the sample code shown in the blog post, and that module also exports the `ajax` function, the cleanest update is to change all `$.ajax(...)` calls to just `utils.ajax(...)` calls.  For the modules that did not already require the utils module, I added that in to provide the right ajax call.