### PR TITLE
Use conda 4.4+-style install for Travis-CI (conda activate, ...)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - . "$HOME/miniconda/etc/profile.d/conda.sh"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update --yes --quiet conda
@@ -29,7 +29,7 @@ install:
   - conda info -a
   - conda create -n nb_conda python=$TRAVIS_PYTHON_VERSION
   - conda install -n nb_conda -c conda-forge --file requirements.txt
-  - source activate nb_conda
+  - conda activate nb_conda
   - pip install python-coveralls
   - npm install
 


### PR DESCRIPTION
This patch causes Travis to install and use miniconda in the conda 4.4 way: 
-running conda.sh as a shell script instead of adding $HOME/miniconda3/bin to the path
-activating with `conda activate <env>`

This style of installation and use would seem to be the future. However I'm not sure that we shouldn't be testing **both** methods, since the miniconda installer and instructions at conda.io still tell the user to add the base bin directory to their path.

Also, I'm not familiar with conda installation on windows, so this PR doesn't touch the AppVeyor stuff.