### PR TITLE
Resolve Flake8 bare exception error in test

### DIFF
--- a/nb_conda/tests/test_notebook.py
+++ b/nb_conda/tests/test_notebook.py
@@ -106,7 +106,7 @@ class NBCondaTestController(jstest.JSController):
         if self.url:
             try:
                 alive = jstest.requests.get(self.url).status_code == 200
-            except:
+            except BaseException:
                 alive = False
 
             if alive:


### PR DESCRIPTION
The bare exception in test results in an exception being raised 2 lines later.